### PR TITLE
Update ucsc_tools version to 357

### DIFF
--- a/recipes/ucsc_tools/meta.yaml
+++ b/recipes/ucsc_tools/meta.yaml
@@ -1,19 +1,19 @@
 package:
   name: ucsc_tools
-  version: "332"
+  version: "357"
 
 build:
   number: 1
 
 requirements:
   run:
-    - ucsc-bedgraphtobigwig ==332
-    - ucsc-bedtobigbed ==332
-    - ucsc-fatotwobit ==332
-    - ucsc-liftover ==332
-    - ucsc-nibfrag ==332
-    - ucsc-twobittofa ==332
-    - ucsc-wigtobigwig ==332
+    - ucsc-bedgraphtobigwig ==357
+    - ucsc-bedtobigbed ==357
+    - ucsc-fatotwobit ==357
+    - ucsc-liftover ==357
+    - ucsc-nibfrag ==357
+    - ucsc-twobittofa ==357
+    - ucsc-wigtobigwig ==357
 
 test:
   commands:

--- a/recipes/ucsc_tools/meta.yaml
+++ b/recipes/ucsc_tools/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "357"
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   run:


### PR DESCRIPTION
As some shipped-with-Galaxy converters have unversioned requirements on `ucsc_tools`, and because of bioconda/bioconda-recipes#5430, installing the `ucsc_tools` package currently installs broken binaries.

I'll also update the tools in Galaxy so they depend directly on the per-binary Bioconda packages, but for older Galaxies I think updating this is the right solution.